### PR TITLE
BRSTM encoding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,4 +258,7 @@ paket-files/
 #Audio files for testing
 *.wav
 *.dsp
+*.brstm
+*.bcstm
+*.bfstm
 /DspAdpcm/DspAdpcm.Cli/Properties/launchSettings.json

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -526,17 +526,17 @@ namespace DspAdpcm.Encode.Adpcm
             }
         }
 
-        public static void SetLoopContext(IAdpcmChannel audio, int loopStart)
+        public static void SetLoopContext(this IAdpcmChannel audio, int loopStart)
         {
             short hist1 = 0;
             short hist2 = 0;
             int currentSample = 0;
 
-            foreach (var block in audio.AudioData.Batch(8))
+            foreach (byte[] block in audio.AudioData.Batch(8))
             {
-                var ps = block[0];
-                var scale = 1 << (ps & 0xf);
-                var predictor = (ps >> 4) & 0xf;
+                byte ps = block[0];
+                int scale = 1 << (ps & 0xf);
+                int predictor = (ps >> 4) & 0xf;
                 short coef1 = audio.Coefs[predictor * 2];
                 short coef2 = audio.Coefs[predictor * 2 + 1];
                 var samples = new int[14];

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -194,6 +194,9 @@ namespace DspAdpcm.Encode.Adpcm.Formats
 
             chunk.Add32("ADPC");
             chunk.Add32BE(AdpcChunkLength);
+            chunk.AddRange(new byte[8]); //Pad to 0x10 bytes
+
+            chunk.AddRange(AudioStream.Channels.BuildAdpcTable(SamplesPerAdpcEntry, NumAdpcEntries));
 
             chunk.AddRange(new byte[AdpcChunkLength - chunk.Count]);
 

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -204,8 +204,13 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             chunk.Add32("DATA");
             chunk.Add32BE(DataChunkLength);
             chunk.Add32BE(0x18);
+            chunk.AddRange(new byte[0x14]); //Pad to 0x20 bytes
 
-            chunk.AddRange(new byte[DataChunkLength - chunk.Count]);
+            List<IEnumerable<byte>> channels = Enumerable.Range(0, NumChannels)
+                .Select((x, index) => AudioStream.Channels[index].AudioData)
+                .ToList();
+
+            chunk.AddRange(channels.Interleave(InterleaveSize, LastBlockSize));
 
             return chunk.ToArray();
         }

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -1,0 +1,213 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static DspAdpcm.Encode.Helpers;
+
+namespace DspAdpcm.Encode.Adpcm.Formats
+{
+    public class Brstm
+    {
+        public IAdpcmStream AudioStream { get; set; }
+        
+        private int NumSamples => AudioStream.NumSamples;
+        private int NumChannels => AudioStream.Channels.Count;
+        private byte Codec { get; } = 2; // 4-bit ADPCM
+        private byte Looping => (byte)(AudioStream.Looping ? 1 : 0);
+        private int AudioDataOffset => DataChunkOffset + 0x20;
+        private int InterleaveSize => GetBytesForAdpcmSamples(SamplesPerInterleave);
+        private int SamplesPerInterleave => 0x3800;
+        private int InterleaveCount => (NumSamples / SamplesPerInterleave) + (LastBlockSamples == 0 ? 0 : 1);
+        private int LastBlockSizeWithoutPadding => GetBytesForAdpcmSamples(LastBlockSamples);
+        private int LastBlockSamples => NumSamples % SamplesPerInterleave;
+        private int LastBlockSize => GetNextMultiple(LastBlockSizeWithoutPadding, 0x20);
+        private int SamplesPerAdpcEntry => 0x3800;
+        private int NumAdpcEntries => (NumSamples / SamplesPerAdpcEntry) - (LastBlockSamples == 0 ? 1 : 0);
+        private int BytesPerAdpcEntry => 4; //Or is it bits per sample?
+
+        private int RstmHeaderLength => 0x40;
+
+        private int HeadChunkOffset => RstmHeaderLength;
+        private int HeadChunkLength => GetNextMultiple(HeadChunkHeaderLength + HeadChunkTableLength +
+            HeadChunk1Length + HeadChunk2Length + HeadChunk3Length, 0x20);
+        private int HeadChunkHeaderLength = 8;
+        private int HeadChunkTableLength => 8 * 3;
+        private int HeadChunk1Length => 0x34;
+        private int HeadChunk2Length => 0x10;
+        private int HeadChunk3Length => 4 + (8 * NumChannels) + (ChannelInfoLength * NumChannels);
+        private int ChannelInfoLength => 0x38;
+
+        private int AdpcChunkOffset => RstmHeaderLength + HeadChunkLength;
+        private int AdpcChunkLength => GetNextMultiple(0x10 + NumAdpcEntries * NumChannels * BytesPerAdpcEntry, 0x20);
+
+        private int DataChunkOffset => RstmHeaderLength + HeadChunkLength + AdpcChunkLength;
+        private int DataChunkLength => GetNextMultiple(0x20 + (InterleaveCount - (LastBlockSamples == 0 ? 0 : 1)) * InterleaveSize * NumChannels + LastBlockSize * NumChannels, 0x20);
+
+        private int FileLength => RstmHeaderLength + HeadChunkLength + AdpcChunkLength + DataChunkLength;
+
+        public Brstm(IAdpcmStream stream)
+        {
+            if (stream.Channels.Count < 1)
+            {
+                throw new InvalidDataException("Stream must have at least one channel ");
+            }
+
+            AudioStream = stream;
+        }
+
+        public IEnumerable<byte> GetFile()
+        {
+            return GetRstmHeader().Concat(GetHeadChunk()).Concat(GetAdpcChunk()).Concat(GetDataChunk());
+        }
+
+        private byte[] GetRstmHeader()
+        {
+            var header = new List<byte>();
+
+            header.Add32("RSTM");
+            header.Add16BE(0xfeff); //Endianness
+            header.Add16BE(0x0100); //BRSTM format version
+            header.Add32BE(FileLength);
+            header.Add16BE(RstmHeaderLength);
+            header.Add16BE(2); // NumEntries
+            header.Add32BE(HeadChunkOffset);
+            header.Add32BE(HeadChunkLength);
+            header.Add32BE(AdpcChunkOffset);
+            header.Add32BE(AdpcChunkLength);
+            header.Add32BE(DataChunkOffset);
+            header.Add32BE(DataChunkLength);
+
+            header.AddRange(new byte[RstmHeaderLength - header.Count]);
+
+            return header.ToArray();
+        }
+
+        private byte[] GetHeadChunk()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add32("HEAD");
+            chunk.Add32BE(HeadChunkLength);
+            chunk.AddRange(GetHeadChunkHeader());
+            chunk.AddRange(GetHeadChunk1());
+            chunk.AddRange(GetHeadChunk2());
+            chunk.AddRange(GetHeadChunk3());
+
+            chunk.AddRange(new byte[HeadChunkLength - chunk.Count]);
+
+            return chunk.ToArray();
+        }
+
+        private byte[] GetHeadChunkHeader()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add32BE(0x01000000);
+            chunk.Add32BE(HeadChunkTableLength); //Chunk 1 offset
+            chunk.Add32BE(0x01000000);
+            chunk.Add32BE(HeadChunkTableLength + HeadChunk1Length); //Chunk 1 offset
+            chunk.Add32BE(0x01000000);
+            chunk.Add32BE(HeadChunkTableLength + HeadChunk1Length + HeadChunk2Length); //Chunk 3 offset
+
+            return chunk.ToArray();
+        }
+
+        private byte[] GetHeadChunk1()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add(Codec);
+            chunk.Add(Looping);
+            chunk.Add((byte)NumChannels);
+            chunk.Add(0); //padding
+            chunk.Add16BE(AudioStream.SampleRate);
+            chunk.Add16BE(0); //padding
+            chunk.Add32BE(AudioStream.LoopStart);
+            chunk.Add32BE(AudioStream.NumSamples);
+            chunk.Add32BE(AudioDataOffset);
+            chunk.Add32BE(InterleaveCount);
+            chunk.Add32BE(InterleaveSize);
+            chunk.Add32BE(SamplesPerInterleave);
+            chunk.Add32BE(LastBlockSizeWithoutPadding);
+            chunk.Add32BE(LastBlockSamples);
+            chunk.Add32BE(LastBlockSize);
+            chunk.Add32BE(SamplesPerAdpcEntry);
+            chunk.Add32BE(BytesPerAdpcEntry);
+
+            return chunk.ToArray();
+        }
+
+        //Not sure what this chunk is for
+        private byte[] GetHeadChunk2()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add32BE(0x01000000);
+            chunk.Add32BE(0x01000000);
+            chunk.Add32BE(0x58);
+            chunk.Add32BE(NumChannels == 1 ? 0x01000000 : 0x02000100);
+
+            return chunk.ToArray();
+        }
+
+        private byte[] GetHeadChunk3()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add((byte)NumChannels);
+            chunk.Add(0); //padding
+            chunk.Add16BE(0); //padding
+
+            int baseOffset = HeadChunkTableLength + HeadChunk1Length + HeadChunk2Length + 4;
+            int offsetTableLength = NumChannels * 8;
+
+            for (int i = 0; i < NumChannels; i++)
+            {
+                chunk.Add32BE(0x01000000);
+                chunk.Add32BE(baseOffset + offsetTableLength + ChannelInfoLength * i);
+            }
+
+            for (int i = 0; i < NumChannels; i++)
+            {
+                IAdpcmChannel channel = AudioStream.Channels[i];
+                chunk.Add32BE(0x01000000);
+                chunk.Add32BE(baseOffset + offsetTableLength + ChannelInfoLength * i + 8);
+                chunk.AddRange(channel.Coefs.SelectMany(x => x.ToBytesBE()));
+                chunk.Add16BE(channel.Gain);
+                chunk.Add16BE(channel.AudioData.First());
+                chunk.Add16BE(channel.Hist1);
+                chunk.Add16BE(channel.Hist2);
+                chunk.Add16BE(channel.LoopPredScale);
+                chunk.Add16BE(channel.LoopHist1);
+                chunk.Add16BE(channel.LoopHist2);
+                chunk.Add16(0);
+            }
+
+            return chunk.ToArray();
+        }
+
+        private byte[] GetAdpcChunk()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add32("ADPC");
+            chunk.Add32BE(AdpcChunkLength);
+
+            chunk.AddRange(new byte[AdpcChunkLength - chunk.Count]);
+
+            return chunk.ToArray();
+        }
+
+        private byte[] GetDataChunk()
+        {
+            var chunk = new List<byte>();
+
+            chunk.Add32("DATA");
+            chunk.Add32BE(DataChunkLength);
+            chunk.Add32BE(0x18);
+
+            chunk.AddRange(new byte[DataChunkLength - chunk.Count]);
+
+            return chunk.ToArray();
+        }
+    }
+}

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using static DspAdpcm.Encode.Helpers;
 
 namespace DspAdpcm.Encode.Adpcm.Formats
@@ -159,6 +160,8 @@ namespace DspAdpcm.Encode.Adpcm.Formats
 
             int baseOffset = HeadChunkTableLength + HeadChunk1Length + HeadChunk2Length + 4;
             int offsetTableLength = NumChannels * 8;
+
+            Parallel.ForEach(AudioStream.Channels, x => x.SetLoopContext(AudioStream.LoopStart));
 
             for (int i = 0; i < NumChannels; i++)
             {

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Dsp.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Dsp.cs
@@ -33,7 +33,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
         {
             if (AudioStream.Looping)
             {
-                Adpcm.Encode.SetLoopContext(AudioChannel, AudioStream.LoopStart);
+                AudioChannel.SetLoopContext(AudioStream.LoopStart);
             }
 
             var header = new List<byte>();

--- a/DspAdpcm/DspAdpcm.Encode/DspAdpcm.Encode.csproj
+++ b/DspAdpcm/DspAdpcm.Encode/DspAdpcm.Encode.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Adpcm\AdpcmChannel.cs" />
     <Compile Include="Adpcm\AdpcmStream.cs" />
     <Compile Include="Adpcm\Encode.cs" />
+    <Compile Include="Adpcm\Formats\Brstm.cs" />
     <Compile Include="Adpcm\Formats\DspLR.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Adpcm\IAdpcmStream.cs" />

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DspAdpcm.Encode
 {
     public static class Extensions
     {
-        public static IEnumerable<T[]> Batch<T>(
-        this IEnumerable<T> source, int size)
+        public static IEnumerable<T[]> Batch<T>(this IEnumerable<T> source, int size, int lastSize = -1)
         {
+            if (lastSize == -1 || lastSize > size)
+                lastSize = size;
+
             T[] bucket = new T[size];
             var count = 0;
 
@@ -26,7 +29,25 @@ namespace DspAdpcm.Encode
 
             // Return the last bucket with all remaining elements
             if (count > 0)
-                yield return bucket;
+                yield return bucket.Take(lastSize).ToArray();
+        }
+
+        public static IEnumerable<T> Interleave<T>(this IEnumerable<IEnumerable<T>> channels, int interleaveSize, int lastInterleaveSize)
+        {
+            IEnumerable<IEnumerable<T[]>> batchedAudioData = channels
+                .Select(channel => channel.Batch(interleaveSize, lastInterleaveSize));
+
+            IEnumerable<IEnumerable<T>> interleavedBlocks = batchedAudioData
+                .Zip(channel => channel.SelectMany(batch => batch));
+
+            return interleavedBlocks.SelectMany(x => x);
+        }
+
+        public static IEnumerable<TResult> Zip<T, TResult>(this IEnumerable<IEnumerable<T>> sequences, Func<T[], TResult> resultSelector)
+        {
+            IEnumerator<T>[] enumerators = sequences.Select(s => s.GetEnumerator()).ToArray();
+            while (enumerators.All(e => e.MoveNext()))
+                yield return resultSelector(enumerators.Select(e => e.Current).ToArray());
         }
     }
 }

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -23,7 +23,7 @@ namespace DspAdpcm.Encode
 
                 yield return bucket;
 
-                Array.Clear(bucket, 0, size);
+                bucket = new T[size];
                 count = 0;
             }
 

--- a/DspAdpcm/DspAdpcm.Encode/Helpers.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace DspAdpcm.Encode
 {
@@ -50,7 +51,26 @@ namespace DspAdpcm.Encode
             return (short)value;
         }
 
-        public static IEnumerable<byte> ToBytesBE(this int input) => BitConverter.GetBytes(input).Reverse();
-        public static IEnumerable<byte> ToBytesBE(this short input) => BitConverter.GetBytes(input).Reverse();
+        public static int GetNextMultiple(int value, int multiple)
+        {
+            if (multiple <= 0)
+                return value;
+
+            if (value % multiple == 0)
+                return value;
+
+            return value + multiple - value % multiple;
+        }
+
+        public static IEnumerable<byte> ToBytesBE(this int value) => BitConverter.GetBytes(value).Reverse();
+        public static IEnumerable<byte> ToBytesBE(this short value) => BitConverter.GetBytes(value).Reverse();
+        public static IEnumerable<byte> ToBytesBE(this ushort value) => BitConverter.GetBytes(value).Reverse();
+        public static void Add16BE(this List<byte> list, int value) => list.Add16BE((short) value);
+        public static void Add16BE(this List<byte> list, short value) => list.AddRange(value.ToBytesBE());
+        public static void Add16BE(this List<byte> list, ushort value) => list.AddRange(value.ToBytesBE());
+        public static void Add32BE(this List<byte> list, int value) => list.AddRange(value.ToBytesBE());
+        public static void Add16(this List<byte> list, short value) => list.AddRange(BitConverter.GetBytes(value));
+        public static void Add32(this List<byte> list, int value) => list.AddRange(BitConverter.GetBytes(value));
+        public static void Add32(this List<byte> list, string value) => list.AddRange(Encoding.ASCII.GetBytes(value.PadRight(4, '\0').Substring(0, 4)));
     }
 }


### PR DESCRIPTION
Add support for BRSTM writing. This code currently uses a lot of LINQ, which for some reason is pretty slow. Need to do some more testing with that.

Instead of the ADPC table being based off the input PCM audio like in BrawlTools' encoder, it's based off of the encoded ADPCM data. This allows for rebuilding of the ADPC table without the original audio.

Currently only the header format found in Super Smash Bros. Brawl is written, but it shouldn't be too hard to add support for other header formats.