### PR TITLE
Increase performance of building brstm files

### DIFF
--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -660,7 +660,7 @@ namespace DspAdpcm.Encode.Adpcm
                     ).ToArray();
             });
 
-            return entries.Interleave(2, 2)
+            return entries.Interleave2(2, 2)
                 .SelectMany(x =>
                     BitConverter.GetBytes(x)
                     .Reverse()

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -645,18 +645,22 @@ namespace DspAdpcm.Encode.Adpcm
 
         public static IEnumerable<byte> BuildAdpcTable(this IEnumerable<IAdpcmChannel> channels, int samplesPerAdpcEntry, int numAdpcEntries)
         {
-            return channels
-                .Select(x => x
-                    .GetPcmAudio()
+            var channelsArray = channels.ToArray();
+            var entries = new short[channelsArray.Length][];
+
+            Parallel.For(0, channelsArray.Length, i =>
+            {
+                entries[i] = channelsArray[i].GetPcmAudio()
                     .Batch(samplesPerAdpcEntry)
                     .Take(numAdpcEntries)
                     .SelectMany(y => y
                         .Skip(samplesPerAdpcEntry - 2)
                         .Take(2)
                         .Reverse()
-                    )
-                )
-                .Interleave(2, 2)
+                    ).ToArray();
+            });
+
+            return entries.Interleave(2, 2)
                 .SelectMany(x =>
                     BitConverter.GetBytes(x)
                     .Reverse()

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -643,7 +643,7 @@ namespace DspAdpcm.Encode.Adpcm
             return adpcm;
         }
 
-        public static IEnumerable<byte> BuildAdpcTable(this IEnumerable<IAdpcmChannel> channels, int samplesPerAdpcEntry, int numAdpcEntries)
+        public static IEnumerable<byte> BuildAdpcTable(IEnumerable<IAdpcmChannel> channels, int samplesPerAdpcEntry, int numAdpcEntries)
         {
             var channelsArray = channels.ToArray();
             var entries = new short[channelsArray.Length][];
@@ -660,7 +660,7 @@ namespace DspAdpcm.Encode.Adpcm
                     ).ToArray();
             });
 
-            return entries.Interleave2(2, 2)
+            return entries.Interleave(2)
                 .SelectMany(x =>
                     BitConverter.GetBytes(x)
                     .Reverse()

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -212,10 +212,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             chunk.Add32BE(0x18);
             chunk.AddRange(new byte[0x14]); //Pad to 0x20 bytes
 
-            List<IEnumerable<byte>> channels = Enumerable.Range(0, NumChannels)
-                .Select((x, index) => AudioStream.Channels[index].AudioData)
-                .ToList();
-
+            var channels = AudioStream.Channels.Select(x => x.AudioData.ToArray()).ToArray();
             chunk.AddRange(channels.Interleave(InterleaveSize, LastBlockSize));
 
             return chunk.ToArray();

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -161,7 +161,10 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             int baseOffset = HeadChunkTableLength + HeadChunk1Length + HeadChunk2Length + 4;
             int offsetTableLength = NumChannels * 8;
 
-            Parallel.ForEach(AudioStream.Channels, x => x.SetLoopContext(AudioStream.LoopStart));
+            if (AudioStream.Looping)
+            {
+                Parallel.ForEach(AudioStream.Channels, x => x.SetLoopContext(AudioStream.LoopStart));
+            }
 
             for (int i = 0; i < NumChannels; i++)
             {
@@ -196,7 +199,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             chunk.Add32BE(AdpcChunkLength);
             chunk.AddRange(new byte[8]); //Pad to 0x10 bytes
 
-            chunk.AddRange(AudioStream.Channels.BuildAdpcTable(SamplesPerAdpcEntry, NumAdpcEntries));
+            chunk.AddRange(Encode.BuildAdpcTable(AudioStream.Channels, SamplesPerAdpcEntry, NumAdpcEntries));
 
             chunk.AddRange(new byte[AdpcChunkLength - chunk.Count]);
 

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -57,7 +57,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
 
         public IEnumerable<byte> GetFile()
         {
-            return GetRstmHeader().Concat(GetHeadChunk()).Concat(GetAdpcChunk()).Concat(GetDataChunk());
+            return Combine(GetRstmHeader(), GetHeadChunk(), GetAdpcChunk(), GetDataChunk());
         }
 
         private byte[] GetRstmHeader()

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -33,7 +33,39 @@ namespace DspAdpcm.Encode
                 yield return bucket.Take(lastSize).ToArray();
         }
 
-        public static IEnumerable<T> Interleave<T>(this IEnumerable<IEnumerable<T>> channels, int interleaveSize, int lastInterleaveSize)
+        public static T[] Interleave<T>(this T[][] inputs, int interleaveSize, int lastInterleaveSize)
+        {
+            int length = inputs[0].Length;
+            if (inputs.Any(x => x.Length != length))
+                throw new ArgumentOutOfRangeException(nameof(inputs), "Inputs must be of equal length");
+
+            int numInputs = inputs.Length;
+            int numBlocks = length / interleaveSize;
+            var output = new T[interleaveSize * numInputs * numBlocks + lastInterleaveSize * numInputs];
+
+            for (int b = 0; b < numBlocks; b++)
+            {
+                for (int i = 0; i < numInputs; i++)
+                {
+                    Array.Copy(inputs[i], interleaveSize * b,
+                        output, interleaveSize * b * numInputs + interleaveSize * i,
+                        interleaveSize);
+                }
+            }
+
+            if (length % interleaveSize == 0) return output;
+
+            for (int i = 0; i < numInputs; i++)
+            {
+                Array.Copy(inputs[i], interleaveSize * numBlocks,
+                    output, interleaveSize * numBlocks * numInputs + lastInterleaveSize * i,
+                    lastInterleaveSize);
+            }
+
+            return output;
+        }
+
+        public static IEnumerable<T> Interleave2<T>(this IEnumerable<IEnumerable<T>> channels, int interleaveSize, int lastInterleaveSize)
         {
             IEnumerable<IEnumerable<T[]>> batchedAudioData = channels
                 .Select(channel => channel.Batch(interleaveSize, lastInterleaveSize));
@@ -51,7 +83,7 @@ namespace DspAdpcm.Encode
                 yield return resultSelector(enumerators.Select(e => e.Current).ToArray());
         }
 
-        public static int ReadInt32BE(this BinaryReader reader) => 
+        public static int ReadInt32BE(this BinaryReader reader) =>
             BitConverter.ToInt32(reader.ReadBytes(sizeof(int)).Reverse().ToArray(), 0);
 
         public static short ReadInt16BE(this BinaryReader reader) =>

--- a/DspAdpcm/DspAdpcm.Encode/Helpers.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Helpers.cs
@@ -71,6 +71,18 @@ namespace DspAdpcm.Encode
             return value + multiple - value % multiple;
         }
 
+        public static byte[] Combine(params byte[][] arrays)
+        {
+            var ret = new byte[arrays.Sum(x => x.Length)];
+            int offset = 0;
+            foreach (byte[] data in arrays)
+            {
+                Buffer.BlockCopy(data, 0, ret, offset, data.Length);
+                offset += data.Length;
+            }
+            return ret;
+        }
+
         public static IEnumerable<byte> ToBytesBE(this int value) => BitConverter.GetBytes(value).Reverse();
         public static IEnumerable<byte> ToBytesBE(this short value) => BitConverter.GetBytes(value).Reverse();
         public static IEnumerable<byte> ToBytesBE(this ushort value) => BitConverter.GetBytes(value).Reverse();


### PR DESCRIPTION
Move away from using LINQ in building brstm files. Turns out using LINQ was at least an order of magnitude slower than simply copying arrays around in some cases.