### PR TITLE
Add support for reading brstm files

### DIFF
--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -650,11 +650,10 @@ namespace DspAdpcm.Encode.Adpcm
 
             Parallel.For(0, channelsArray.Length, i =>
             {
-                entries[i] = channelsArray[i].GetPcmAudio()
+                entries[i] = channelsArray[i].GetPcmAudio(true)
                     .Batch(samplesPerAdpcEntry)
                     .Take(numAdpcEntries)
                     .SelectMany(y => y
-                        .Skip(samplesPerAdpcEntry - 2)
                         .Take(2)
                         .Reverse()
                     ).ToArray();

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -23,7 +23,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
         private int LastBlockSamples => NumSamples % SamplesPerInterleave;
         private int LastBlockSize => GetNextMultiple(LastBlockSizeWithoutPadding, 0x20);
         private int SamplesPerAdpcEntry { get; set; } = 0x3800;
-        private int NumAdpcEntries => (NumSamples / SamplesPerAdpcEntry) - (LastBlockSamples == 0 ? 1 : 0);
+        private int NumAdpcEntries => 1 + (NumSamples / SamplesPerAdpcEntry) - (LastBlockSamples == 0 ? 1 : 0);
         private int BytesPerAdpcEntry => 4; //Or is it bits per sample?
 
         private int RstmHeaderLength { get; set; } = 0x40;
@@ -39,7 +39,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
         private int ChannelInfoLength => 0x38;
 
         private int AdpcChunkOffset => RstmHeaderLength + HeadChunkLength;
-        private int AdpcChunkLength => GetNextMultiple(0x10 + NumAdpcEntries * NumChannels * BytesPerAdpcEntry, 0x20);
+        private int AdpcChunkLength => GetNextMultiple(8 + NumAdpcEntries * NumChannels * BytesPerAdpcEntry, 0x20);
 
         private int DataChunkOffset => RstmHeaderLength + HeadChunkLength + AdpcChunkLength;
         private int DataChunkLength => GetNextMultiple(0x20 + (InterleaveCount - (LastBlockSamples == 0 ? 0 : 1)) * InterleaveSize * NumChannels + LastBlockSize * NumChannels, 0x20);
@@ -218,7 +218,6 @@ namespace DspAdpcm.Encode.Adpcm.Formats
 
             chunk.Add32("ADPC");
             chunk.Add32BE(AdpcChunkLength);
-            chunk.AddRange(new byte[8]); //Pad to 0x10 bytes
 
             chunk.AddRange(Encode.BuildAdpcTable(AudioStream.Channels, SamplesPerAdpcEntry, NumAdpcEntries));
 

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using static DspAdpcm.Encode.Helpers;
 
@@ -9,23 +10,23 @@ namespace DspAdpcm.Encode.Adpcm.Formats
     public class Brstm
     {
         public IAdpcmStream AudioStream { get; set; }
-        
+
         private int NumSamples => AudioStream.NumSamples;
         private int NumChannels => AudioStream.Channels.Count;
         private byte Codec { get; } = 2; // 4-bit ADPCM
         private byte Looping => (byte)(AudioStream.Looping ? 1 : 0);
         private int AudioDataOffset => DataChunkOffset + 0x20;
         private int InterleaveSize => GetBytesForAdpcmSamples(SamplesPerInterleave);
-        private int SamplesPerInterleave => 0x3800;
+        private int SamplesPerInterleave { get; set; } = 0x3800;
         private int InterleaveCount => (NumSamples / SamplesPerInterleave) + (LastBlockSamples == 0 ? 0 : 1);
         private int LastBlockSizeWithoutPadding => GetBytesForAdpcmSamples(LastBlockSamples);
         private int LastBlockSamples => NumSamples % SamplesPerInterleave;
         private int LastBlockSize => GetNextMultiple(LastBlockSizeWithoutPadding, 0x20);
-        private int SamplesPerAdpcEntry => 0x3800;
+        private int SamplesPerAdpcEntry { get; set; } = 0x3800;
         private int NumAdpcEntries => (NumSamples / SamplesPerAdpcEntry) - (LastBlockSamples == 0 ? 1 : 0);
         private int BytesPerAdpcEntry => 4; //Or is it bits per sample?
 
-        private int RstmHeaderLength => 0x40;
+        private int RstmHeaderLength { get; set; } = 0x40;
 
         private int HeadChunkOffset => RstmHeaderLength;
         private int HeadChunkLength => GetNextMultiple(HeadChunkHeaderLength + HeadChunkTableLength +
@@ -33,7 +34,7 @@ namespace DspAdpcm.Encode.Adpcm.Formats
         private int HeadChunkHeaderLength = 8;
         private int HeadChunkTableLength => 8 * 3;
         private int HeadChunk1Length => 0x34;
-        private int HeadChunk2Length => 0x10;
+        private int HeadChunk2Length { get; set; } = 0x10;
         private int HeadChunk3Length => 4 + (8 * NumChannels) + (ChannelInfoLength * NumChannels);
         private int ChannelInfoLength => 0x38;
 
@@ -53,6 +54,11 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             }
 
             AudioStream = stream;
+        }
+
+        public Brstm(Stream stream)
+        {
+            ReadBrstmFile(stream);
         }
 
         public IEnumerable<byte> GetFile()
@@ -219,6 +225,190 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             chunk.AddRange(channels.Interleave(InterleaveSize, LastBlockSize));
 
             return chunk.ToArray();
+        }
+
+        public void ReadBrstmFile(Stream stream)
+        {
+            using (var reader = new BinaryReader(stream))
+            {
+                if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "RSTM")
+                {
+                    throw new InvalidDataException("File has no RSTM header");
+                }
+
+                var structure = new BrstmStructure();
+
+                reader.BaseStream.Position = 8;
+                structure.FileLength = reader.ReadInt32BE();
+                structure.RstmHeaderLength = reader.ReadInt16BE();
+                reader.BaseStream.Position += 2;
+
+                structure.HeadChunkOffset = reader.ReadInt32BE();
+                structure.HeadChunkLengthRstm = reader.ReadInt32BE();
+                structure.AdpcChunkOffset = reader.ReadInt32BE();
+                structure.AdpcChunkLengthRstm = reader.ReadInt32BE();
+                structure.DataChunkOffset = reader.ReadInt32BE();
+                structure.DataChunkLengthRstm = reader.ReadInt32BE();
+
+                reader.BaseStream.Position = structure.HeadChunkOffset;
+                byte[] headChunk = reader.ReadBytes(structure.HeadChunkLengthRstm);
+                ParseHeadChunk(headChunk, structure);
+            }
+        }
+
+        private static void ParseHeadChunk(byte[] head, BrstmStructure structure)
+        {
+            int baseOffset = 8;
+
+            if (Encoding.UTF8.GetString(head, 0, 4) != "HEAD")
+            {
+                throw new InvalidDataException("Unknown or invalid HEAD chunk");
+            }
+
+            using (var reader = new BinaryReader(new MemoryStream(head)))
+            {
+                reader.BaseStream.Position = 4;
+                if (reader.ReadInt32BE() != head.Length)
+                {
+                    throw new InvalidDataException("HEAD chunk stated length does not match actual length");
+                }
+
+                reader.BaseStream.Position += 4;
+                structure.HeadChunk1Offset = reader.ReadInt32BE();
+                reader.BaseStream.Position += 4;
+                structure.HeadChunk2Offset = reader.ReadInt32BE();
+                reader.BaseStream.Position += 4;
+                structure.HeadChunk3Offset = reader.ReadInt32BE();
+
+                reader.BaseStream.Position = structure.HeadChunk1Offset + baseOffset;
+                byte[] headChunk1 = reader.ReadBytes(structure.HeadChunk1Length);
+
+                reader.BaseStream.Position = structure.HeadChunk3Offset + baseOffset;
+                byte[] headChunk3 = reader.ReadBytes(structure.HeadChunk3Length);
+
+                ParseHeadChunk1(headChunk1, structure);
+                ParseHeadChunk3(headChunk3, structure);
+            }
+        }
+
+        private static void ParseHeadChunk1(byte[] chunk, BrstmStructure structure)
+        {
+            using (var reader = new BinaryReader(new MemoryStream(chunk)))
+            {
+                structure.Codec = reader.ReadByte();
+                if (structure.Codec != 2) //4-bit ADPCM codec
+                {
+                    throw new InvalidDataException("File must contain 4-bit ADPCM encoded audio");
+                }
+
+                structure.Looping = reader.ReadByte() == 1;
+                structure.NumChannelsChunk1 = reader.ReadByte();
+                reader.BaseStream.Position += 1;
+
+                structure.SampleRate = reader.ReadInt16BE();
+                reader.BaseStream.Position += 2;
+
+                structure.LoopStart = reader.ReadInt32BE();
+                structure.NumSamples = reader.ReadInt32BE();
+
+                structure.AudioDataOffset = reader.ReadInt32BE();
+                structure.InterleaveCount = reader.ReadInt32BE();
+                structure.InterleaveSize = reader.ReadInt32BE();
+                structure.SamplesPerInterleave = reader.ReadInt32BE();
+                structure.LastBlockSizeWithoutPadding = reader.ReadInt32BE();
+                structure.LastBlockSamples = reader.ReadInt32BE();
+                structure.LastBlockSize = reader.ReadInt32BE();
+                structure.SamplesPerAdpcEntry = reader.ReadInt32BE();
+            }
+        }
+
+        private static void ParseHeadChunk3(byte[] chunk, BrstmStructure structure)
+        {
+            using (var reader = new BinaryReader(new MemoryStream(chunk)))
+            {
+                structure.NumChannelsChunk3 = reader.ReadByte();
+                reader.BaseStream.Position += 3;
+
+                var channels = new List<ChannelInfo>();
+
+                for (int i = 0; i < structure.NumChannelsChunk3; i++)
+                {
+                    var channel = new ChannelInfo();
+                    reader.BaseStream.Position += 4;
+                    channel.Offset = reader.ReadInt32BE();
+                    channels.Add(channel);
+                }
+
+                int baseOffset = structure.HeadChunk3Offset;
+                foreach (ChannelInfo channel in channels)
+                {
+                    reader.BaseStream.Position = channel.Offset - structure.HeadChunk3Offset + 4;
+                    int coefsOffset = reader.ReadInt32BE();
+                    reader.BaseStream.Position = coefsOffset - structure.HeadChunk3Offset;
+
+                    channel.Coefs = Enumerable.Range(0, 16).Select(x => reader.ReadInt16BE()).ToArray();
+                    channel.Gain = reader.ReadInt16BE();
+                    channel.PredScale = reader.ReadInt16BE();
+                    channel.Hist1 = reader.ReadInt16BE();
+                    channel.Hist2 = reader.ReadInt16BE();
+                    channel.LoopPredScale = reader.ReadInt16BE();
+                    channel.LoopHist1 = reader.ReadInt16BE();
+                    channel.LoopHist2 = reader.ReadInt16BE();
+                }
+            }
+        }
+
+        private class BrstmStructure
+        {
+            public int FileLength { get; set; }
+            public int RstmHeaderLength { get; set; }
+            public int HeadChunkOffset { get; set; }
+            public int HeadChunkLengthRstm { get; set; }
+            public int AdpcChunkOffset { get; set; }
+            public int AdpcChunkLengthRstm { get; set; }
+            public int DataChunkOffset { get; set; }
+            public int DataChunkLengthRstm { get; set; }
+
+            public int HeadChunkLength { get; set; }
+            public int HeadChunk1Offset { get; set; }
+            public int HeadChunk2Offset { get; set; }
+            public int HeadChunk3Offset { get; set; }
+            public int HeadChunk1Length => HeadChunk2Offset - HeadChunk1Offset;
+            public int HeadChunk2Length => HeadChunk3Offset - HeadChunk2Offset;
+            public int HeadChunk3Length => AdpcChunkOffset - HeadChunk3Offset;
+
+            public int Codec { get; set; }
+            public bool Looping { get; set; }
+            public int NumChannelsChunk1 { get; set; }
+            public int SampleRate { get; set; }
+            public int LoopStart { get; set; }
+            public int NumSamples { get; set; }
+            public int AudioDataOffset { get; set; }
+            public int InterleaveCount { get; set; }
+            public int InterleaveSize { get; set; }
+            public int SamplesPerInterleave { get; set; }
+            public int LastBlockSizeWithoutPadding { get; set; }
+            public int LastBlockSamples { get; set; }
+            public int LastBlockSize { get; set; }
+            public int SamplesPerAdpcEntry { get; set; }
+
+            public int NumChannelsChunk3 { get; set; }
+        }
+
+        private class ChannelInfo
+        {
+            public int Offset { get; set; }
+
+            public short[] Coefs { get; set; }
+
+            public short Gain { get; set; }
+            public short PredScale { get; set; }
+            public short Hist1 { get; set; } = 0;
+            public short Hist2 { get; set; } = 0;
+
+            public short LoopPredScale { get; set; }
+            public short LoopHist1 { get; set; }
+            public short LoopHist2 { get; set; }
         }
     }
 }

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -78,6 +78,62 @@ namespace DspAdpcm.Encode
             return output;
         }
 
+        public static T[][] DeInterleave<T>(this T[] input, int interleaveSize, int numOutputs, int lastInterleaveSize = -1, int finalOutputLength = -1)
+        {
+            if (lastInterleaveSize < 0 || lastInterleaveSize > interleaveSize)
+                lastInterleaveSize = interleaveSize;
+
+            int inputLength = input.Length;
+
+            if (inputLength % numOutputs != 0)
+                throw new ArgumentOutOfRangeException(nameof(numOutputs), numOutputs,
+                    $"The input array length ({inputLength}) must be divisible by the number of outputs.");
+
+            int outputLength = inputLength / numOutputs;
+            if (finalOutputLength < 0)
+                finalOutputLength = outputLength;
+
+            int numFullBlocks = outputLength / interleaveSize;
+            int numShortBlocks = outputLength % interleaveSize == 0 ? 0 : 1;
+
+            if (numShortBlocks != 0 && outputLength % interleaveSize < lastInterleaveSize)
+                throw new ArgumentOutOfRangeException(nameof(lastInterleaveSize), lastInterleaveSize,
+                    $"Not enough elements for specified last interleave size");
+
+            var outputs = new T[numOutputs][];
+            for (int i = 0; i < numOutputs; i++)
+            {
+                outputs[i] = new T[outputLength];
+            }
+
+            for (int b = 0; b < numFullBlocks; b++)
+            {
+                for (int o = 0; o < numOutputs; o++)
+                {
+                    Array.Copy(input, interleaveSize * b * numOutputs + interleaveSize * o,
+                        outputs[o], interleaveSize * b ,
+                        interleaveSize);
+                }
+            }
+
+            for (int b = 0; b < numShortBlocks; b++)
+            {
+                for (int o = 0; o < numOutputs; o++)
+                {
+                    Array.Copy(input, interleaveSize * numFullBlocks * numOutputs + lastInterleaveSize * o,
+                        outputs[o], interleaveSize * numFullBlocks,
+                        lastInterleaveSize);
+                }
+            }
+
+            for (int i = 0; i < outputs.Length; i++)
+            {
+                Array.Resize(ref outputs[i], finalOutputLength);
+            }
+
+            return outputs;
+        }
+
         public static int ReadInt32BE(this BinaryReader reader) =>
             BitConverter.ToInt32(reader.ReadBytes(sizeof(int)).Reverse().ToArray(), 0);
 


### PR DESCRIPTION
Add support for reading in data from brstm files and tweak a few things about writing them. Reading and writing brstm files with up to at least 8 channels works.  However, I still don't know what the second chunk in the HEAD section of the file is for, and can't rebuild that part yet on >2-channel brstms.