### PR TITLE
Make output match Nintendo's DSP-ADPCM v2.3 encoder's implementation

### DIFF
--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -423,7 +423,7 @@ namespace DspAdpcm.Encode.Adpcm
             }
 
             int[] scale = new int[8];
-            int[] distAccum = new int[8];
+            double[] distAccum = new double[8];
 
             /* Iterate through each coef set, finding the set with the smallest error */
             for (int i = 0; i < 8; i++)
@@ -440,7 +440,7 @@ namespace DspAdpcm.Encode.Adpcm
                 for (int s = 0; s < sampleCount; s++)
                 {
                     /* Multiply previous samples by coefs */
-                    inSamples[i][s + 2] = v1 = ((pcmInOut[s] * coefs[i][1]) + (pcmInOut[s + 1] * coefs[i][0])) >> 11;
+                    inSamples[i][s + 2] = v1 = ((pcmInOut[s] * coefs[i][1]) + (pcmInOut[s + 1] * coefs[i][0])) / 2048;
                     /* Subtract from current sample */
                     v2 = pcmInOut[s + 2] - v1;
                     /* Clamp */
@@ -451,7 +451,7 @@ namespace DspAdpcm.Encode.Adpcm
                 }
 
                 /* Set initial scale */
-                for (scale[i] = 0; (scale[i] <= 12) && ((distance > 7) || (distance < -8)); scale[i]++, distance >>= 1) { }
+                for (scale[i] = 0; (scale[i] <= 12) && ((distance > 7) || (distance < -8)); scale[i]++, distance /=2) { }
                 scale[i] = (scale[i] <= 1) ? -1 : scale[i] - 2;
 
                 do
@@ -492,7 +492,7 @@ namespace DspAdpcm.Encode.Adpcm
                         inSamples[i][s + 2] = v2 = Clamp16(v1);
                         /* Accumulate distance */
                         v3 = pcmInOut[s + 2] - v2;
-                        distAccum[i] += v3 * v3;
+                        distAccum[i] += v3 * (double)v3;
                     }
 
                     for (int x = index + 8; x > 256; x >>= 1)
@@ -504,7 +504,8 @@ namespace DspAdpcm.Encode.Adpcm
 
             int bestIndex = 0;
 
-            for (int i = 0, min = int.MaxValue; i < 8; i++)
+            double min = double.MaxValue;
+            for (int i = 0; i < 8; i++)
             {
                 if (distAccum[i] < min)
                 {


### PR DESCRIPTION
Make output match Nintendo's DSP-ADPCM v2.3 encoder's non-SIMD implementation.  The SIMD implementation varies ever-so-slightly from the non-SIMD implementation. We're talking thousandths of a percent difference when doing a byte-by-byte comparison. Later versions of Nintendo's encoder change the output a bit, so this C# version will stick with v2.3.