### PR TITLE
Add new options for the ADPCM seek table

### DIFF
--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/AdpcmChannel.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/AdpcmChannel.cs
@@ -19,7 +19,9 @@ namespace DspAdpcm.Encode.Adpcm
         public short LoopPredScale { get; private set; }
         public short LoopHist1 { get; private set; }
         public short LoopHist2 { get; private set; }
-        
+
+        public short[] SeekTable { get; set; } = null;
+        public int SamplesPerSeekTableEntry { get; set; }
 
         public AdpcmChannel(int numSamples)
         {

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -710,7 +710,7 @@ namespace DspAdpcm.Encode.Adpcm
             Parallel.ForEach(channels, channel => CalculateAdpcTable(channel, samplesPerEntry));
         }
 
-        internal static IEnumerable<byte> BuildAdpcTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry)
+        internal static IEnumerable<byte> BuildAdpcTable(IEnumerable<AdpcmChannel> channels, int samplesPerEntry, int numEntries)
         {
             channels = channels.ToList();
             CalculateAdpcTable(channels.Where(x => 
@@ -723,7 +723,8 @@ namespace DspAdpcm.Encode.Adpcm
                 .SelectMany(x =>
                     BitConverter.GetBytes(x)
                     .Reverse()
-                );
+                )
+                .Take(numEntries * 4 * channels.Count());
         }
     }
 }

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Encode.cs
@@ -695,9 +695,9 @@ namespace DspAdpcm.Encode.Adpcm
         {
             channel.SeekTable = 
                 channel.GetPcmAudio(true)
-                .Batch(samplesPerEntry)
+                .Batch(samplesPerEntry, true)
                 .SelectMany(y => y
-                    .Take(2)
+                    .Take(y.Length > 2 ? 2 : 0)
                     .Reverse()
                 )
                 .ToArray();

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -22,12 +22,14 @@ namespace DspAdpcm.Encode.Adpcm.Formats
         private int AudioDataOffset => DataChunkOffset + 0x20;
         private int InterleaveSize => GetBytesForAdpcmSamples(SamplesPerInterleave);
         private int SamplesPerInterleave => Math.Min(Configuration.SamplesPerInterleave, NumSamples);
-        private int InterleaveCount => (NumSamples / SamplesPerInterleave) + (LastBlockSamples == 0 ? 0 : 1);
+        private int InterleaveCount => (NumSamples / SamplesPerInterleave) + (FullLastBlock ? 0 : 1);
         private int LastBlockSizeWithoutPadding => GetBytesForAdpcmSamples(LastBlockSamples);
-        private int LastBlockSamples => NumSamples % SamplesPerInterleave;
+        private int LastBlockSamples => FullLastBlock ? SamplesPerInterleave : NumSamples % SamplesPerInterleave;
         private int LastBlockSize => GetNextMultiple(LastBlockSizeWithoutPadding, 0x20);
+        private bool FullLastBlock => NumSamples % SamplesPerInterleave == 0 && NumChannels > 0;
         private int SamplesPerAdpcEntry => Math.Min(Configuration.SamplesPerAdpcEntry, NumSamples);
-        private int NumAdpcEntries => 1 + (NumSamples / SamplesPerAdpcEntry) - (LastBlockSamples == 0 ? 1 : 0);
+        private bool FullLastAdpcEntry => NumSamples % SamplesPerAdpcEntry == 0 && NumChannels > 0;
+        private int NumAdpcEntries => (NumSamples / SamplesPerAdpcEntry) + (FullLastAdpcEntry ? 0 : 1);
         private int BytesPerAdpcEntry => 4; //Or is it bits per sample?
 
         private int RstmHeaderLength => 0x40;

--- a/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Adpcm/Formats/Brstm.cs
@@ -234,7 +234,8 @@ namespace DspAdpcm.Encode.Adpcm.Formats
             chunk.Add32("ADPC");
             chunk.Add32BE(AdpcChunkLength);
 
-            chunk.AddRange(Encode.BuildAdpcTable(AudioStream.Channels, SamplesPerAdpcEntry, NumAdpcEntries));
+            Encode.CalculateAdpcTable(AudioStream.Channels, SamplesPerAdpcEntry);
+            chunk.AddRange(Encode.BuildAdpcTable(AudioStream.Channels, SamplesPerAdpcEntry));
 
             chunk.AddRange(new byte[AdpcChunkLength - chunk.Count]);
 

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -8,11 +8,8 @@ namespace DspAdpcm.Encode
 {
     internal static class Extensions
     {
-        public static IEnumerable<T[]> Batch<T>(this IEnumerable<T> source, int size, int lastSize = -1)
+        public static IEnumerable<T[]> Batch<T>(this IEnumerable<T> source, int size, bool truncateLastBatch = false)
         {
-            if (lastSize < 0 || lastSize > size)
-                lastSize = size;
-
             T[] bucket = new T[size];
             var count = 0;
 
@@ -31,7 +28,7 @@ namespace DspAdpcm.Encode
 
             // Return the last bucket with all remaining elements
             if (count > 0)
-                yield return bucket.Take(lastSize).ToArray();
+                yield return bucket.Take(truncateLastBatch ? count : size).ToArray();
         }
 
         public static T[] Interleave<T>(this T[][] inputs, int interleaveSize, int lastInterleaveSize = -1)

--- a/DspAdpcm/DspAdpcm.Encode/Extensions.cs
+++ b/DspAdpcm/DspAdpcm.Encode/Extensions.cs
@@ -132,6 +132,8 @@ namespace DspAdpcm.Encode
             return outputs;
         }
 
+        public static short FlipBytes(this short value) => (short)(value << 8 | (ushort) value >> 8);
+
         public static IEnumerable<byte> ToBytesBE(this int value) => BitConverter.GetBytes(value).Reverse();
         public static IEnumerable<byte> ToBytesBE(this short value) => BitConverter.GetBytes(value).Reverse();
         public static void Add16BE(this List<byte> list, int value) => list.Add16BE((short)value);


### PR DESCRIPTION
This adds the option to use a shortened seek table as used in games including Pokemon Battle Revolution and Mario Party 8.

It also adds the option to not recalculate the seek table when building a file.