### PR TITLE
Reduce memory allocations and moving data around in memory when reading and building files

### DIFF
--- a/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
@@ -433,7 +433,7 @@ namespace DspAdpcm.Lib.Adpcm.Formats
                 structure.NumChannelsChunk1 = reader.ReadByte();
                 reader.BaseStream.Position += 1;
 
-                structure.SampleRate = reader.ReadInt16BE();
+                structure.SampleRate = (ushort)reader.ReadInt16BE();
                 reader.BaseStream.Position += 2;
 
                 structure.LoopStart = reader.ReadInt32BE();

--- a/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
@@ -115,7 +115,6 @@ namespace DspAdpcm.Lib.Adpcm.Formats
         /// Builds a BRSTM file from the current <see cref="AudioStream"/>.
         /// </summary>
         /// <returns>A BRSTM file</returns>
-
         public byte[] GetFile()
         {
             RecalculateData();
@@ -132,6 +131,29 @@ namespace DspAdpcm.Lib.Adpcm.Formats
             GetDataChunk(data);
 
             return file;
+        }
+
+        /// <summary>
+        /// Writes the BRSTM file to a <see cref="Stream"/>.
+        /// The file is written starting at the beginning
+        /// of the <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The <see cref="Stream"/> to write the
+        /// BRSTM to.</param>
+        public void WriteFile(Stream stream)
+        {
+            RecalculateData();
+
+            stream.SetLength(FileLength);
+
+            stream.Position = 0;
+            GetRstmHeader(stream);
+            stream.Position = HeadChunkOffset;
+            GetHeadChunk(stream);
+            stream.Position = AdpcChunkOffset;
+            GetAdpcChunk(stream);
+            stream.Position = DataChunkOffset;
+            GetDataChunk(stream);
         }
 
         private void GetRstmHeader(Stream stream)
@@ -296,7 +318,7 @@ namespace DspAdpcm.Lib.Adpcm.Formats
             chunk.WriteBE(DataChunkLength);
             chunk.WriteBE(0x18);
 
-            stream.Position = AudioDataOffset - DataChunkOffset;
+            stream.Position += AudioDataOffset - DataChunkOffset - 3 * sizeof(int);
 
             byte[][] channels = AudioStream.Channels.Select(x => x.AudioByteArray).ToArray();
 

--- a/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
@@ -561,10 +561,8 @@ namespace DspAdpcm.Lib.Adpcm.Formats
             reader.BaseStream.Position = structure.AudioDataOffset;
             int audioDataLength = structure.DataChunkLength - (structure.AudioDataOffset - structure.DataChunkOffset);
 
-            byte[] audioData = reader.ReadBytes(audioDataLength);
-
-            byte[][] deInterleavedAudioData = audioData.DeInterleave(structure.InterleaveSize, structure.NumChannelsChunk1,
-                structure.LastBlockSize, GetBytesForAdpcmSamples(structure.NumSamples));
+            byte[][] deInterleavedAudioData = reader.BaseStream.DeInterleave(audioDataLength, structure.InterleaveSize,
+                structure.NumChannelsChunk1, structure.LastBlockSize, GetBytesForAdpcmSamples(structure.NumSamples));
 
             for (int c = 0; c < structure.NumChannelsChunk1; c++)
             {

--- a/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
+++ b/DspAdpcm/DspAdpcm.Lib/Adpcm/Formats/Brstm.cs
@@ -300,9 +300,7 @@ namespace DspAdpcm.Lib.Adpcm.Formats
 
             byte[][] channels = AudioStream.Channels.Select(x => x.AudioByteArray).ToArray();
 
-            var interleavedData = channels.Interleave(InterleaveSize, LastBlockSize);
-
-            chunk.Write(interleavedData);
+            channels.Interleave(stream, InterleaveSize, LastBlockSize);
         }
 
         private void ReadBrstmFile(Stream stream)

--- a/DspAdpcm/DspAdpcm.Lib/BinaryWriterBE.cs
+++ b/DspAdpcm/DspAdpcm.Lib/BinaryWriterBE.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DspAdpcm.Lib
+{
+    class BinaryWriterBE : BinaryWriter
+    {
+        public BinaryWriterBE(Stream input) : base(input)
+        {
+            _buffer = new byte[16];
+        }
+
+        private byte[] _buffer;
+
+        public void WriteBE(short value)
+        {
+            _buffer[0] = (byte)(value >> 8);
+            _buffer[1] = (byte)value;
+            OutStream.Write(_buffer, 0, 2);
+        }
+
+        public void WriteBE(ushort value)
+        {
+            _buffer[0] = (byte)(value >> 8);
+            _buffer[1] = (byte)value;
+            OutStream.Write(_buffer, 0, 2);
+        }
+
+        public void WriteBE(int value)
+        {
+            _buffer[0] = (byte)(value >> 24);
+            _buffer[1] = (byte)(value >> 16);
+            _buffer[2] = (byte)(value >> 8);
+            _buffer[3] = (byte)value;
+            OutStream.Write(_buffer, 0, 4);
+        }
+
+        public void WriteASCII(string value)
+        {
+            byte[] text = System.Text.Encoding.ASCII.GetBytes(value);
+            Write(text);
+        }
+    }
+}

--- a/DspAdpcm/DspAdpcm.Lib/DspAdpcm.Lib.csproj
+++ b/DspAdpcm/DspAdpcm.Lib/DspAdpcm.Lib.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Adpcm\Formats\Brstm.cs" />
     <Compile Include="Adpcm\Formats\DspLR.cs" />
     <Compile Include="BinaryReaderBE.cs" />
+    <Compile Include="BinaryWriterBE.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Adpcm\Formats\Dsp.cs" />


### PR DESCRIPTION
Reading and then writing a file now only does a single whole-file memory allocation instead of 3-4+.
Large increase in speed when reading, converting, and then writing a file. (100%+)